### PR TITLE
Improve diagnostics for failing patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <version>9</version>
   </parent>
 
   <groupId>com.github.stephenc.diffpatch</groupId>
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>com.googlecode.java-diff-utils</groupId>
       <artifactId>diffutils</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/github/stephenc/diffpatch/ApplyMojo.java
+++ b/src/main/java/io/github/stephenc/diffpatch/ApplyMojo.java
@@ -137,9 +137,9 @@ public class ApplyMojo extends AbstractMojo {
                 FileUtils.writeLines(patchedFile, encoding, patch.applyTo(FileUtils.readLines(sourceFile, encoding)));
                 new FileOutputStream(markerFile).close();
             } catch (IOException e) {
-                throw new MojoExecutionException("Could not apply patch", e);
+                throw new MojoExecutionException("Could not apply patch to " + newFile, e);
             } catch (PatchFailedException e) {
-                throw new MojoExecutionException("Could not apply patch", e);
+                throw new MojoExecutionException("Could not apply patch to " + newFile, e);
             }
         }
     }


### PR DESCRIPTION
This is a minor patch, which slightly improves error messages when a patch fails.

- [x] - Reference the failing target file in the `MojoExecutionException`
- [x] - Update diffutils to the latest version. There are some error propagation improvements

@reviewbybees @v1v